### PR TITLE
fix: Change GitHubUser id type to number

### DIFF
--- a/src/pages/login/github/callback.ts
+++ b/src/pages/login/github/callback.ts
@@ -5,7 +5,7 @@ import { OAuth2RequestError } from "arctic";
 import type { APIContext } from "astro";
 
 type GitHubUser = {
-  id: string;
+  id: number;
   login: string;
   avatar_url: string;
 };


### PR DESCRIPTION
Modified the id type of GitHubUser from string to number to ensure compatibility with the data type used in the API response. This change is necessary for accurate data handling and to prevent potential errors in the application.