### PR TITLE
feat: Render dynamic course title on course page

### DIFF
--- a/src/pages/courses/[id].astro
+++ b/src/pages/courses/[id].astro
@@ -1,7 +1,12 @@
 ---
+import { Course, db } from "astro:db";
 import Layout from "@/layouts/Layout.astro";
+
+const course = await db.select().from(Course).get();
 ---
 
-<Layout title="kjbnkn">
-<h1>kjdhcjhsjhd</h1>
+<Layout title={course?.title ?? 'The Learnary'}>
+  <main class="page-container">
+    <h1>{course?.title}</h1>
+  </main>
 </Layout>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
 @import "https://unpkg.com/open-props/normalize.light.min.css";
 
 :root {
+    --brand: wheat;
     --color-primary: wheat;
     --color-border: hsl(210 16.7% 95.3%);
 }


### PR DESCRIPTION
- Fetch course data from database using Astro db
- Display the course title dynamically on the page
- Refactor layout to show course title in h1 tag
- Update styles to use a brand color variable
- Default title to 'The Learnary' if course title is not available